### PR TITLE
Clean up wordpress-org code standards

### DIFF
--- a/admin/class-login-and-logout-redirect-admin.php
+++ b/admin/class-login-and-logout-redirect-admin.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LoginAndLogoutRedirect;
+
 /**
  * The admin-specific functionality of the plugin.
  *
@@ -20,7 +22,7 @@
  * @subpackage Login_And_Logout_Redirect/admin
  * @author     Swapnil V. Patil <patilswapnilv@gmail.com>
  */
-class Login_And_Logout_Redirect_Admin {
+class LoginAndLogoutRedirectAdmin {
 
     /**
      * The ID of this plugin.
@@ -65,15 +67,21 @@ class Login_And_Logout_Redirect_Admin {
          * This function is provided for demonstration purposes only.
          *
          * An instance of this class should be passed to the run() function
-         * defined in Login_And_Logout_Redirect_Loader as all of the hooks are defined
+         * defined in LoginAndLogoutRedirectLoader as all of the hooks are defined
          * in that particular class.
          *
-         * The Login_And_Logout_Redirect_Loader will then create the relationship
+         * The LoginAndLogoutRedirectLoader will then create the relationship
          * between the defined hooks and the functions defined in this
          * class.
          */
 
-        wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/login-and-logout-redirect-admin.css', array(), $this->version, 'all' );
+        wp_enqueue_style(
+            $this->plugin_name,
+            plugin_dir_url( __FILE__ ) . 'css/login-and-logout-redirect-admin.css',
+            array(),
+            $this->version,
+            'all'
+        );
 
     }
 
@@ -88,15 +96,21 @@ class Login_And_Logout_Redirect_Admin {
          * This function is provided for demonstration purposes only.
          *
          * An instance of this class should be passed to the run() function
-         * defined in Login_And_Logout_Redirect_Loader as all of the hooks are defined
+         * defined in LoginAndLogoutRedirectLoader as all of the hooks are defined
          * in that particular class.
          *
-         * The Login_And_Logout_Redirect_Loader will then create the relationship
+         * The LoginAndLogoutRedirectLoader will then create the relationship
          * between the defined hooks and the functions defined in this
          * class.
          */
 
-        wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/login-and-logout-redirect-admin.js', array( 'jquery' ), $this->version, false );
+        wp_enqueue_script(
+            $this->plugin_name,
+            plugin_dir_url( __FILE__ ) . 'js/login-and-logout-redirect-admin.js',
+            array( 'jquery' ),
+            $this->version,
+            false
+        );
 
     }
 

--- a/includes/class-login-and-logout-redirect-activator.php
+++ b/includes/class-login-and-logout-redirect-activator.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LoginAndLogoutRedirect;
+
 /**
  * Fired during plugin activation
  *
@@ -20,7 +22,7 @@
  * @subpackage Login_And_Logout_Redirect/includes
  * @author     Swapnil V. Patil <patilswapnilv@gmail.com>
  */
-class Login_And_Logout_Redirect_Activator {
+class LoginAndLogoutRedirectActivator {
 
     /**
      * Short Description. (use period)

--- a/includes/class-login-and-logout-redirect-deactivator.php
+++ b/includes/class-login-and-logout-redirect-deactivator.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LoginAndLogoutRedirect;
+
 /**
  * Fired during plugin deactivation
  *
@@ -20,7 +22,7 @@
  * @subpackage Login_And_Logout_Redirect/includes
  * @author     Swapnil V. Patil <patilswapnilv@gmail.com>
  */
-class Login_And_Logout_Redirect_Deactivator {
+class LoginAndLogoutRedirectDeactivator {
 
     /**
      * Short Description. (use period)

--- a/includes/class-login-and-logout-redirect-i18n.php
+++ b/includes/class-login-and-logout-redirect-i18n.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LoginAndLogoutRedirect;
+
 /**
  * Define the internationalization functionality
  *
@@ -24,7 +26,7 @@
  * @subpackage Login_And_Logout_Redirect/includes
  * @author     Swapnil V. Patil <patilswapnilv@gmail.com>
  */
-class Login_And_Logout_Redirect_i18n {
+class LoginAndLogoutRedirectI18n {
 
 
     /**

--- a/includes/class-login-and-logout-redirect-loader.php
+++ b/includes/class-login-and-logout-redirect-loader.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LoginAndLogoutRedirect;
+
 /**
  * Register all actions and filters for the plugin
  *
@@ -21,7 +23,7 @@
  * @subpackage Login_And_Logout_Redirect/includes
  * @author     Swapnil V. Patil <patilswapnilv@gmail.com>
  */
-class Login_And_Logout_Redirect_Loader {
+class LoginAndLogoutRedirectLoader {
 
     /**
      * The array of actions registered with WordPress.
@@ -57,11 +59,11 @@ class Login_And_Logout_Redirect_Loader {
      * Add a new action to the collection to be registered with WordPress.
      *
      * @since    1.0.4
-     * @param    string               $hook             The name of the WordPress action that is being registered.
-     * @param    object               $component        A reference to the instance of the object on which the action is defined.
-     * @param    string               $callback         The name of the function definition on the $component.
-     * @param    int                  $priority         Optional. The priority at which the function should be fired. Default is 10.
-     * @param    int                  $accepted_args    Optional. The number of arguments that should be passed to the $callback. Default is 1.
+     * @param    string    $hook          The name of the WordPress action that is being registered.
+     * @param    object    $component     A reference to the instance of the object on which the action is defined.
+     * @param    string    $callback      The name of the function definition on the $component.
+     * @param    int       $priority      Optional. The priority at which the function should be fired. Default is 10.
+     * @param    int       $accepted_args Optional. The number of arguments that should be passed to the $callback. Default is 1.
      */
     public function add_action( $hook, $component, $callback, $priority = 10, $accepted_args = 1 ) {
         $this->actions = $this->add( $this->actions, $hook, $component, $callback, $priority, $accepted_args );
@@ -71,11 +73,11 @@ class Login_And_Logout_Redirect_Loader {
      * Add a new filter to the collection to be registered with WordPress.
      *
      * @since    1.0.4
-     * @param    string               $hook             The name of the WordPress filter that is being registered.
-     * @param    object               $component        A reference to the instance of the object on which the filter is defined.
-     * @param    string               $callback         The name of the function definition on the $component.
-     * @param    int                  $priority         Optional. The priority at which the function should be fired. Default is 10.
-     * @param    int                  $accepted_args    Optional. The number of arguments that should be passed to the $callback. Default is 1
+     * @param    string    $hook          The name of the WordPress filter that is being registered.
+     * @param    object    $component     A reference to the instance of the object on which the filter is defined.
+     * @param    string    $callback      The name of the function definition on the $component.
+     * @param    int       $priority      Optional. The priority at which the function should be fired. Default is 10.
+     * @param    int       $accepted_args Optional. The number of arguments that should be passed to the $callback. Default is 1
      */
     public function add_filter( $hook, $component, $callback, $priority = 10, $accepted_args = 1 ) {
         $this->filters = $this->add( $this->filters, $hook, $component, $callback, $priority, $accepted_args );
@@ -87,12 +89,12 @@ class Login_And_Logout_Redirect_Loader {
      *
      * @since    1.0.4
      * @access   private
-     * @param    array                $hooks            The collection of hooks that is being registered (that is, actions or filters).
-     * @param    string               $hook             The name of the WordPress filter that is being registered.
-     * @param    object               $component        A reference to the instance of the object on which the filter is defined.
-     * @param    string               $callback         The name of the function definition on the $component.
-     * @param    int                  $priority         The priority at which the function should be fired.
-     * @param    int                  $accepted_args    The number of arguments that should be passed to the $callback.
+     * @param    array     $hooks         The collection of hooks that is being registered (that is, actions or filters).
+     * @param    string    $hook          The name of the WordPress filter that is being registered.
+     * @param    object    $component     A reference to the instance of the object on which the filter is defined.
+     * @param    string    $callback      The name of the function definition on the $component.
+     * @param    int       $priority      The priority at which the function should be fired.
+     * @param    int       $accepted_args The number of arguments that should be passed to the $callback.
      * @return   array                                  The collection of actions and filters registered with WordPress.
      */
     private function add( $hooks, $hook, $component, $callback, $priority, $accepted_args ) {

--- a/includes/class-login-and-logout-redirect.php
+++ b/includes/class-login-and-logout-redirect.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LoginAndLogoutRedirect;
+
 /**
  * The file that defines the core plugin class
  *
@@ -27,7 +29,7 @@
  * @subpackage Login_And_Logout_Redirect/includes
  * @author     Swapnil V. Patil <patilswapnilv@gmail.com>
  */
-class Login_And_Logout_Redirect {
+class LoginAndLogoutRedirect {
 
     /**
      * The loader that's responsible for maintaining and registering all hooks that power

--- a/includes/class-login-redirect.php
+++ b/includes/class-login-redirect.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LoginAndLogoutRedirect;
+
 /**
  * Plugin class for Login-redirect
  *
@@ -10,21 +12,13 @@
  *   @link     https://github.com/patilswapnilv/login-and-logout-redirect/readme.md
  *   @return   boolean
  * */
-class Login_Redirect
+class LoginRedirect
 {
-
-    /**
-     * PHP 4 constructor
-     * */
-    function Login_Redirect()
-    {
-        __construct();
-    }
 
     /**
      * PHP 5 constructor
      * */
-    function __construct()
+    public function __construct()
     {
         if (!isset($_REQUEST['redirect_to']) || $_REQUEST['redirect_to'] == admin_url()) {
             add_filter('login_redirect', array(&$this, 'redirect'), 10, 3);
@@ -45,7 +39,7 @@ class Login_Redirect
     /**
      * Redirect user on login
      * */
-    function redirect($redirect_to, $requested_redirect_to, $user)
+    public function redirect($redirect_to, $requested_redirect_to, $user)
     {
         $interim_login = isset($_REQUEST['interim-login']);
         $reauth = empty($_REQUEST['reauth']) ? false : true;
@@ -67,7 +61,7 @@ class Login_Redirect
     /**
      * Network option
      * */
-    function network_option()
+    public function network_option()
     {
         if (!$this->is_plugin_active_for_network(plugin_basename(__FILE__))) {
             return;
@@ -90,7 +84,7 @@ class Login_Redirect
     /**
      * Save option in the option
      * */
-    function update_network_option()
+    public function update_network_option()
     {
         update_site_option('login_redirect_url', stripslashes($_POST['login_redirect_url']));
     }
@@ -98,7 +92,7 @@ class Login_Redirect
     /**
      * Add setting field for singlesite
      * */
-    function add_settings_field()
+    public function add_settings_field()
     {
         if ($this->is_plugin_active_for_network(plugin_basename(__FILE__))) {
             return;
@@ -114,7 +108,7 @@ class Login_Redirect
     /**
      * Setting field for singlesite
      * */
-    function site_option()
+    public function site_option()
     {
         echo '<input name="login_redirect_url" type="text" id="login_redirect_url" value="'.esc_attr(get_option('login_redirect_url')).'" size="40" />';
     }
@@ -123,7 +117,7 @@ class Login_Redirect
      * Verify if plugin is network activated
      * @return boolean
      */
-    function is_plugin_active_for_network($plugin)
+    public function is_plugin_active_for_network($plugin)
     {
         if (!is_multisite()) {
             return false;

--- a/public/class-login-and-logout-redirect-public.php
+++ b/public/class-login-and-logout-redirect-public.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace LoginAndLogoutRedirect;
+
 /**
  * The public-facing functionality of the plugin.
  *
@@ -20,7 +22,7 @@
  * @subpackage Login_And_Logout_Redirect/public
  * @author     Swapnil V. Patil <patilswapnilv@gmail.com>
  */
-class Login_And_Logout_Redirect_Public {
+class LoginAndLogoutRedirectPublic {
 
     /**
      * The ID of this plugin.
@@ -65,15 +67,21 @@ class Login_And_Logout_Redirect_Public {
          * This function is provided for demonstration purposes only.
          *
          * An instance of this class should be passed to the run() function
-         * defined in Login_And_Logout_Redirect_Loader as all of the hooks are defined
+         * defined in LoginAndLogoutRedirectLoader as all of the hooks are defined
          * in that particular class.
          *
-         * The Login_And_Logout_Redirect_Loader will then create the relationship
+         * The LoginAndLogoutRedirectLoader will then create the relationship
          * between the defined hooks and the functions defined in this
          * class.
          */
 
-        wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/login-and-logout-redirect-public.css', array(), $this->version, 'all' );
+        wp_enqueue_style(
+            $this->plugin_name,
+            plugin_dir_url( __FILE__ ) . 'css/login-and-logout-redirect-public.css',
+            array(),
+            $this->version,
+            'all'
+        );
 
     }
 
@@ -88,15 +96,21 @@ class Login_And_Logout_Redirect_Public {
          * This function is provided for demonstration purposes only.
          *
          * An instance of this class should be passed to the run() function
-         * defined in Login_And_Logout_Redirect_Loader as all of the hooks are defined
+         * defined in LoginAndLogoutRedirectLoader as all of the hooks are defined
          * in that particular class.
          *
-         * The Login_And_Logout_Redirect_Loader will then create the relationship
+         * The LoginAndLogoutRedirectLoader will then create the relationship
          * between the defined hooks and the functions defined in this
          * class.
          */
 
-        wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/login-and-logout-redirect-public.js', array( 'jquery' ), $this->version, false );
+        wp_enqueue_script(
+            $this->plugin_name,
+            plugin_dir_url( __FILE__ ) . 'js/login-and-logout-redirect-public.js',
+            array( 'jquery' ),
+            $this->version,
+            false
+        );
 
     }
 


### PR DESCRIPTION
Apply PHP coding standards by implementing namespaces, renaming classes to PascalCase, adding visibility declarations, and refactoring long lines for readability.

---
<a href="https://cursor.com/background-agent?bcId=bc-fc48f562-2bca-4f57-beec-13b1d1958c88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fc48f562-2bca-4f57-beec-13b1d1958c88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal code structure with namespace organization for improved maintainability.
  * Updated class naming conventions to follow modern PHP standards.
  * Explicitly marked method visibility declarations for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->